### PR TITLE
Wait for sdcard in service.sh

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -12,8 +12,9 @@ lock_val() {
 	fi
 }
 
-while [ "$(getprop sys.boot_completed)" != 1 ];
-do sleep 3;
+until [ "$(getprop sys.boot_completed)" = "1" ] && \
+[ -d "/sdcard/Android" ]; do
+  sleep 3
 done
 
 MODDIR=${0%/*}


### PR DESCRIPTION
This may fix the 20% not completed issue. Regardless, its good to have in the service.sh file.